### PR TITLE
Update list-all to use HTTPS

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,4 +1,3 @@
 #!/bin/sh 
 
-#curl -s http://grails.org/download.html | grep -oE "<option>(.*?)</option>" | grep -oE "[0-9\.]+" | sort -t. -n | paste -s -d" " -
-curl -s http://grails.org/download.html | grep -oE "<option>(.*?)</option>" | grep -oE "[0-9\.]+" | sort --version-sort | xargs echo
+curl -s https://grails.org/download.html | grep -oE "<option>(.*?)</option>" | grep -oE "[0-9\.]+" | sort --version-sort | xargs echo


### PR DESCRIPTION
updates `list-all` URL to use HTTPS.

old URL now throws a 301, so we could either `-L` or use the proper URL. The latter seems like a  better idea

Also deleted the commented out portion since the current portion works as expected

```
❯ asdf plugin add grails

❯ asdf list all grails | wc -l
       0

❯ asdf plugin remove grails

❯ git clone -q https://github.com/theoretick/asdf-grails.git --branch theoretick-patch-1 ~/.asdf/plugins/grails

❯ asdf list all grails | wc -l
     129
```