### PR TITLE
fix: update list-all to scrape new Apache Grails download page

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,7 @@
 #!/bin/sh 
 
-curl -s https://grails.org/download.html | grep -oE "<option>(.*?)</option>" | grep -oE "[0-9\.]+" | sort --version-sort | xargs echo
+curl -sL https://grails.apache.org/download.html \
+  | grep -oE "(grails/core/[0-9][^/]*/distribution|v[0-9][^']+\.zip)" \
+  | grep -oE "[0-9]+(\.[0-9]+)+" \
+  | sort --version-sort -u \
+  | xargs echo


### PR DESCRIPTION
## Summary

- The Grails project moved from `grails.org` to `grails.apache.org` and the download page was redesigned
- The old `<option>` tags contained plain version strings; the new page uses download URLs as option values
- Updated the regex to extract version numbers from URL path patterns, restoring the full version list from 0.1 through current

## Test plan

- [ ] Run `asdf list all grails` and verify versions are returned (was returning empty before this fix)
- [ ] Confirm versions span the full range (0.1 through latest 7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)